### PR TITLE
Add Txt2 engine data decoder

### DIFF
--- a/src/psd_tools/decoder/tagged_blocks.py
+++ b/src/psd_tools/decoder/tagged_blocks.py
@@ -222,6 +222,11 @@ def _decode_type_tool_object_setting(data, **kwargs):
     )
 
 
+@register(TaggedBlock.TEXT_ENGINE_DATA)
+def _decode_text_engine_data(data, **kwargs):
+    return engine_data.decode(data)
+
+
 @register(TaggedBlock.VECTOR_ORIGINATION_DATA)
 def _decode_vector_origination_data(data, **kwargs):
     fp = io.BytesIO(data)


### PR DESCRIPTION
Add decoder for the missing text data. Unfortunately the internal field names are not available anywhere, and the result still looks cryptic.

```python
dict(psd.decoded_data.layer_and_mask_data.tagged_blocks)[b'Txt2']
```